### PR TITLE
Add images for PHP 8.2

### DIFF
--- a/.ci/tests/test_connection.php
+++ b/.ci/tests/test_connection.php
@@ -37,7 +37,7 @@ function test_pdo_sqlsrv_connection(&$errors)
     $password = getenv('MSSQL_PASSWORD');
 
     try {
-        $connection = new PDO("sqlsrv:server={$host},{$port};Database={$database};ConnectionPooling=0", $username, $password, [
+        $connection = new PDO("sqlsrv:server={$host},{$port};Database={$database};ConnectionPooling=0;Encrypt=no", $username, $password, [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ]);
 

--- a/.ci/tests/test_connection.php
+++ b/.ci/tests/test_connection.php
@@ -9,6 +9,7 @@ function test_sqlsrv_connection(&$errors)
         'UID' => getenv('MSSQL_USERNAME'),
         'PWD' => getenv('MSSQL_PASSWORD'),
         'Database' => getenv('MSSQL_DATABASE'),
+        'Encrypt' => false,
     ]);
 
     if ($connection === false) {

--- a/.ci/tests/test_connection.php
+++ b/.ci/tests/test_connection.php
@@ -5,7 +5,7 @@ function test_sqlsrv_connection(&$errors)
     $host = getenv('MSSQL_HOST');
     $port = getenv('MSSQL_PORT');
 
-    $connection = sqlsrv_connect("${host},${port}", [
+    $connection = sqlsrv_connect("{$host},{$port}", [
         'UID' => getenv('MSSQL_USERNAME'),
         'PWD' => getenv('MSSQL_PASSWORD'),
         'Database' => getenv('MSSQL_DATABASE'),
@@ -37,7 +37,7 @@ function test_pdo_sqlsrv_connection(&$errors)
     $password = getenv('MSSQL_PASSWORD');
 
     try {
-        $connection = new PDO("sqlsrv:server=${host},${port};Database=${database};ConnectionPooling=0", $username, $password, [
+        $connection = new PDO("sqlsrv:server={$host},{$port};Database={$database};ConnectionPooling=0", $username, $password, [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         ]);
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -10,6 +10,61 @@ on:
     - cron: "0 2 * * 0" # Weekly on Sundays at 02:00
 
 jobs:
+  # PHP 8.2 Alpine Linux with Swoole Extension
+  build-8_2-cli-alpine-swoole:
+    uses: ./.github/workflows/create-and-test-docker-image.yml
+    name: namoshek/php-mssql:8.2-cli-alpine-swoole
+    needs: build-8_2-cli-alpine
+    if: ${{ github.event_name != 'pull_request' }}
+    secrets: inherit
+    with:
+      source-directory: 8.2/cli-alpine-swoole
+      image-tag: namoshek/php-mssql:8.2-cli-alpine-swoole
+
+  build-8_2-fpm-alpine-swoole:
+    uses: ./.github/workflows/create-and-test-docker-image.yml
+    name: namoshek/php-mssql:8.2-fpm-alpine-swoole
+    needs: build-8_2-fpm-alpine
+    if: ${{ github.event_name != 'pull_request' }}
+    secrets: inherit
+    with:
+      source-directory: 8.2/fpm-alpine-swoole
+      image-tag: namoshek/php-mssql:8.2-fpm-alpine-swoole
+
+  # PHP 8.2 Alpine Linux
+  build-8_2-cli-alpine:
+    uses: ./.github/workflows/create-and-test-docker-image.yml
+    name: namoshek/php-mssql:8.2-cli-alpine
+    secrets: inherit
+    with:
+      source-directory: 8.2/cli-alpine
+      image-tag: namoshek/php-mssql:8.2-cli-alpine
+
+  build-8_2-fpm-alpine:
+    uses: ./.github/workflows/create-and-test-docker-image.yml
+    name: namoshek/php-mssql:8.2-fpm-alpine
+    secrets: inherit
+    with:
+      source-directory: 8.2/fpm-alpine
+      image-tag: namoshek/php-mssql:8.2-fpm-alpine
+
+  # PHP 8.2 Debian
+  build-8_2-cli:
+    uses: ./.github/workflows/create-and-test-docker-image.yml
+    name: namoshek/php-mssql:8.2-cli
+    secrets: inherit
+    with:
+      source-directory: 8.2/cli
+      image-tag: namoshek/php-mssql:8.2-cli
+
+  build-8_2-fpm:
+    uses: ./.github/workflows/create-and-test-docker-image.yml
+    name: namoshek/php-mssql:8.2-fpm
+    secrets: inherit
+    with:
+      source-directory: 8.2/fpm
+      image-tag: namoshek/php-mssql:8.2-fpm
+
   # PHP 8.1 Alpine Linux with Swoole Extension
   build-8_1-cli-alpine-swoole:
     uses: ./.github/workflows/create-and-test-docker-image.yml

--- a/8.2/cli-alpine-swoole/Dockerfile
+++ b/8.2/cli-alpine-swoole/Dockerfile
@@ -1,0 +1,6 @@
+FROM namoshek/php-mssql:8.2-cli-alpine
+
+# Install the Swoole PHP extension.
+RUN chmod uga+x /usr/bin/install-php-extensions \
+    && sync \
+    && install-php-extensions swoole

--- a/8.2/cli-alpine/Dockerfile
+++ b/8.2/cli-alpine/Dockerfile
@@ -1,0 +1,35 @@
+FROM php:8.2-cli-alpine3.17
+
+ENV ACCEPT_EULA=Y
+
+# Install prerequisites required for tools and extensions installed later on.
+RUN apk add --update bash gnupg less libpng-dev libzip-dev nano nodejs npm su-exec unzip
+
+# Install yarn as global npm package.
+RUN npm install -g yarn
+
+# Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
+RUN curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.sig \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.sig \
+    && curl https://packages.microsoft.com/keys/microsoft.asc  | gpg --import - \
+    && gpg --verify msodbcsql17_17.7.1.1-1_amd64.sig msodbcsql17_17.7.1.1-1_amd64.apk \
+    && gpg --verify mssql-tools_17.7.1.1-1_amd64.sig mssql-tools_17.7.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk mssql-tools_17.7.1.1-1_amd64.apk \
+    && rm *.apk *.sig
+
+# Retrieve the script used to install PHP extensions from the source container.
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/install-php-extensions
+
+# Install required PHP extensions and all their prerequisites available via apt.
+RUN chmod uga+x /usr/bin/install-php-extensions \
+    && sync \
+    && install-php-extensions bcmath ds exif gd intl opcache pcntl pcov pdo_sqlsrv redis sqlsrv zip
+
+# Downloading composer and marking it as executable.
+RUN curl -o /usr/local/bin/composer https://getcomposer.org/composer-stable.phar \
+    && chmod +x /usr/local/bin/composer
+
+# Setting the work directory.
+WORKDIR /var/www

--- a/8.2/cli-alpine/Dockerfile
+++ b/8.2/cli-alpine/Dockerfile
@@ -9,14 +9,14 @@ RUN apk add --update bash gnupg less libpng-dev libzip-dev nano nodejs npm su-ex
 RUN npm install -g yarn
 
 # Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
-RUN curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.sig \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.sig \
+RUN curl -O https://download.microsoft.com/download/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/msodbcsql18_18.1.2.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/mssql-tools18_18.1.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/msodbcsql18_18.1.2.1-1_amd64.sig \
+    && curl -O https://download.microsoft.com/download/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/mssql-tools18_18.1.1.1-1_amd64.sig \
     && curl https://packages.microsoft.com/keys/microsoft.asc  | gpg --import - \
-    && gpg --verify msodbcsql17_17.7.1.1-1_amd64.sig msodbcsql17_17.7.1.1-1_amd64.apk \
-    && gpg --verify mssql-tools_17.7.1.1-1_amd64.sig mssql-tools_17.7.1.1-1_amd64.apk \
-    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk mssql-tools_17.7.1.1-1_amd64.apk \
+    && gpg --verify msodbcsql18_18.1.2.1-1_amd64.sig msodbcsql18_18.1.2.1-1_amd64.apk \
+    && gpg --verify mssql-tools18_18.1.1.1-1_amd64.sig mssql-tools18_18.1.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql18_18.1.2.1-1_amd64.apk mssql-tools18_18.1.1.1-1_amd64.apk \
     && rm *.apk *.sig
 
 # Retrieve the script used to install PHP extensions from the source container.

--- a/8.2/cli/Dockerfile
+++ b/8.2/cli/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update \
 
 # Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update \
-    && apt-get install -y msodbcsql17 mssql-tools unixodbc-dev \
+    && apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Retrieve the script used to install PHP extensions from the source container.

--- a/8.2/cli/Dockerfile
+++ b/8.2/cli/Dockerfile
@@ -1,0 +1,36 @@
+FROM php:8.2-cli-bullseye
+
+ENV ACCEPT_EULA=Y
+
+# Install prerequisites required for tools and extensions installed later on.
+RUN apt-get update \
+    && apt-get install -y apt-transport-https gnupg2 libpng-dev libzip-dev nano unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && apt-get install -y msodbcsql17 mssql-tools unixodbc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Retrieve the script used to install PHP extensions from the source container.
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/install-php-extensions
+
+# Install required PHP extensions and all their prerequisites available via apt.
+RUN chmod uga+x /usr/bin/install-php-extensions \
+    && sync \
+    && install-php-extensions bcmath ds exif gd intl opcache pcntl pcov pdo_sqlsrv redis sqlsrv zip
+
+# Downloading composer and marking it as executable.
+RUN curl -o /usr/local/bin/composer https://getcomposer.org/composer-stable.phar \
+    && chmod +x /usr/local/bin/composer
+
+# Downloading and installing nodejs as well as the yarn package manager.
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm install -g yarn
+
+# Setting the work directory.
+WORKDIR /var/www

--- a/8.2/fpm-alpine-swoole/Dockerfile
+++ b/8.2/fpm-alpine-swoole/Dockerfile
@@ -1,0 +1,6 @@
+FROM namoshek/php-mssql:8.2-fpm-alpine
+
+# Install the Swoole PHP extension.
+RUN chmod uga+x /usr/bin/install-php-extensions \
+    && sync \
+    && install-php-extensions swoole

--- a/8.2/fpm-alpine/Dockerfile
+++ b/8.2/fpm-alpine/Dockerfile
@@ -1,0 +1,28 @@
+FROM php:8.2-fpm-alpine3.17
+
+ENV ACCEPT_EULA=Y
+
+# Install prerequisites required for tools and extensions installed later on.
+RUN apk add --update bash gnupg less libpng-dev libzip-dev su-exec unzip
+
+# Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
+RUN curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.sig \
+    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.sig \
+    && curl https://packages.microsoft.com/keys/microsoft.asc  | gpg --import - \
+    && gpg --verify msodbcsql17_17.7.1.1-1_amd64.sig msodbcsql17_17.7.1.1-1_amd64.apk \
+    && gpg --verify mssql-tools_17.7.1.1-1_amd64.sig mssql-tools_17.7.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk mssql-tools_17.7.1.1-1_amd64.apk \
+    && rm *.apk *.sig
+
+# Retrieve the script used to install PHP extensions from the source container.
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/install-php-extensions
+
+# Install required PHP extensions and all their prerequisites available via apt.
+RUN chmod uga+x /usr/bin/install-php-extensions \
+    && sync \
+    && install-php-extensions bcmath ds exif gd intl opcache pcntl pdo_sqlsrv redis sqlsrv zip
+
+# Setting the work directory.
+WORKDIR /var/www

--- a/8.2/fpm-alpine/Dockerfile
+++ b/8.2/fpm-alpine/Dockerfile
@@ -6,14 +6,14 @@ ENV ACCEPT_EULA=Y
 RUN apk add --update bash gnupg less libpng-dev libzip-dev su-exec unzip
 
 # Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
-RUN curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.apk \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.7.1.1-1_amd64.sig \
-    && curl -O https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/mssql-tools_17.7.1.1-1_amd64.sig \
+RUN curl -O https://download.microsoft.com/download/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/msodbcsql18_18.1.2.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/mssql-tools18_18.1.1.1-1_amd64.apk \
+    && curl -O https://download.microsoft.com/download/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/msodbcsql18_18.1.2.1-1_amd64.sig \
+    && curl -O https://download.microsoft.com/download/8/6/8/868e5fc4-7bfe-494d-8f9d-115cbcdb52ae/mssql-tools18_18.1.1.1-1_amd64.sig \
     && curl https://packages.microsoft.com/keys/microsoft.asc  | gpg --import - \
-    && gpg --verify msodbcsql17_17.7.1.1-1_amd64.sig msodbcsql17_17.7.1.1-1_amd64.apk \
-    && gpg --verify mssql-tools_17.7.1.1-1_amd64.sig mssql-tools_17.7.1.1-1_amd64.apk \
-    && apk add --allow-untrusted msodbcsql17_17.7.1.1-1_amd64.apk mssql-tools_17.7.1.1-1_amd64.apk \
+    && gpg --verify msodbcsql18_18.1.2.1-1_amd64.sig msodbcsql18_18.1.2.1-1_amd64.apk \
+    && gpg --verify mssql-tools18_18.1.1.1-1_amd64.sig mssql-tools18_18.1.1.1-1_amd64.apk \
+    && apk add --allow-untrusted msodbcsql18_18.1.2.1-1_amd64.apk mssql-tools18_18.1.1.1-1_amd64.apk \
     && rm *.apk *.sig
 
 # Retrieve the script used to install PHP extensions from the source container.

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update \
 
 # Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
     && apt-get update \
-    && apt-get install -y msodbcsql17 mssql-tools unixodbc-dev \
+    && apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Retrieve the script used to install PHP extensions from the source container.

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -1,0 +1,26 @@
+FROM php:8.2-fpm-bullseye
+
+ENV ACCEPT_EULA=Y
+
+# Install prerequisites required for tools and extensions installed later on.
+RUN apt-get update \
+    && apt-get install -y apt-transport-https gnupg2 libpng-dev libzip-dev unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && apt-get update \
+    && apt-get install -y msodbcsql17 mssql-tools unixodbc-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Retrieve the script used to install PHP extensions from the source container.
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/install-php-extensions
+
+# Install required PHP extensions and all their prerequisites available via apt.
+RUN chmod uga+x /usr/bin/install-php-extensions \
+    && sync \
+    && install-php-extensions bcmath ds exif gd intl opcache pcntl pdo_sqlsrv redis sqlsrv zip
+
+# Setting the work directory.
+WORKDIR /var/www

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To run a container with an image, you can also use `docker run namoshek/php-mssq
 
 For the moment, the primary goal of this repository is to support the following configurations:
 
-- PHP 8.2 (based on Alpine Linux) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
+- PHP 8.2 (based on Alpine Linux) + Microsoft ODBC Driver 18 + sqlsrv + pdo_sqlsrv (FPM and CLI)
 
   - With nano, nodejs, npm, yarn and composer added to the CLI version
   - With bcmath, ds, exif, gd, intl, opcache, pcntl, redis, and zip as additional PHP extensions
@@ -22,7 +22,7 @@ For the moment, the primary goal of this repository is to support the following 
   - Tags: `namoshek/php-mssql:8.2-cli-alpine`, `namoshek/php-mssql:8.2-fpm-alpine`
   - Tags: `namoshek/php-mssql:8.2-cli-alpine-swoole`, `namoshek/php-mssql:8.2-fpm-alpine-swoole` (with Swoole PHP extension)
 
-- PHP 8.2 (based on Debian Bullseye) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
+- PHP 8.2 (based on Debian Bullseye) + Microsoft ODBC Driver 18 + sqlsrv + pdo_sqlsrv (FPM and CLI)
 
   - With nano, nodejs, npm, yarn and composer added to the CLI version
   - With bcmath, ds, exif, gd, intl, opcache, pcntl, redis, and zip as additional PHP extensions

--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ To run a container with an image, you can also use `docker run namoshek/php-mssq
 
 For the moment, the primary goal of this repository is to support the following configurations:
 
-- PHP 8.0 (based on Alpine Linux) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
+- PHP 8.2 (based on Alpine Linux) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
 
   - With nano, nodejs, npm, yarn and composer added to the CLI version
   - With bcmath, ds, exif, gd, intl, opcache, pcntl, redis, and zip as additional PHP extensions
   - With pcov as additional PHP extension on the CLI image
-  - Tags: `namoshek/php-mssql:8.0-cli-alpine`, `namoshek/php-mssql:8.0-fpm-alpine`
-  - Tags: `namoshek/php-mssql:8.0-cli-alpine-swoole`, `namoshek/php-mssql:8.0-fpm-alpine-swoole` (with Swoole PHP extension)
+  - Tags: `namoshek/php-mssql:8.2-cli-alpine`, `namoshek/php-mssql:8.2-fpm-alpine`
+  - Tags: `namoshek/php-mssql:8.2-cli-alpine-swoole`, `namoshek/php-mssql:8.2-fpm-alpine-swoole` (with Swoole PHP extension)
 
-- PHP 8.0 (based on Debian Buster) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
+- PHP 8.2 (based on Debian Bullseye) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
 
   - With nano, nodejs, npm, yarn and composer added to the CLI version
   - With bcmath, ds, exif, gd, intl, opcache, pcntl, redis, and zip as additional PHP extensions
   - With pcov as additional PHP extension on the CLI image
-  - Tags: `namoshek/php-mssql:8.0-cli`, `namoshek/php-mssql:8.0-fpm`
+  - Tags: `namoshek/php-mssql:8.2-cli`, `namoshek/php-mssql:8.2-fpm`
 
 - PHP 8.1 (based on Alpine Linux) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
 
@@ -43,6 +43,21 @@ For the moment, the primary goal of this repository is to support the following 
   - With bcmath, ds, exif, gd, intl, opcache, pcntl, redis, and zip as additional PHP extensions
   - With pcov as additional PHP extension on the CLI image
   - Tags: `namoshek/php-mssql:8.1-cli`, `namoshek/php-mssql:8.1-fpm`
+
+- PHP 8.0 (based on Alpine Linux) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
+
+  - With nano, nodejs, npm, yarn and composer added to the CLI version
+  - With bcmath, ds, exif, gd, intl, opcache, pcntl, redis, and zip as additional PHP extensions
+  - With pcov as additional PHP extension on the CLI image
+  - Tags: `namoshek/php-mssql:8.0-cli-alpine`, `namoshek/php-mssql:8.0-fpm-alpine`
+  - Tags: `namoshek/php-mssql:8.0-cli-alpine-swoole`, `namoshek/php-mssql:8.0-fpm-alpine-swoole` (with Swoole PHP extension)
+
+- PHP 8.0 (based on Debian Buster) + Microsoft ODBC Driver 17 + sqlsrv + pdo_sqlsrv (FPM and CLI)
+
+  - With nano, nodejs, npm, yarn and composer added to the CLI version
+  - With bcmath, ds, exif, gd, intl, opcache, pcntl, redis, and zip as additional PHP extensions
+  - With pcov as additional PHP extension on the CLI image
+  - Tags: `namoshek/php-mssql:8.0-cli`, `namoshek/php-mssql:8.0-fpm`
 
 The exact versions can vary from build to build.
 To see a list of all available tags, please have a look at the [Docker Hub image page](https://hub.docker.com/r/namoshek/php-mssql).


### PR DESCRIPTION
This PR adds new images for PHP 8.2. The new images are very similar to the PHP 8.1 images, with the following major differences:
- The PHP 8.2 Debian images are based on Debian Bullseye, while the PHP 8.1 images are based on Debian Buster.
- The PHP 8.2 Alpine images are based on Alpine Linux 3.17, while the PHP 8.1 images are based on Alpine Linux 3.15.
- The PHP 8.2 images use Node.js v18, while the PHP 8.1 images used Node.js v12.
- The PHP 8.2 images use the Microsoft ODBC 18 driver, while the PHP 8.1 images used the Microsoft ODBC 17 driver.
  - One important breaking change between this two driver version is that with ODBC 18, the `Encrypt` option is enabled by default. Until ODBC 17, it has been disabled by default.