### PR TITLE
Fix: Debian Bullseye build of cli and fpm images

### DIFF
--- a/8.2/cli/Dockerfile
+++ b/8.2/cli/Dockerfile
@@ -8,8 +8,15 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
+# Some packages are pinned with lower priority to prevent build issues due to package conflicts.
+# Link: https://github.com/microsoft/linux-package-repositories/issues/39
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && echo "Package: unixodbc\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
+    && echo "Package: unixodbc-dev\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
+    && echo "Package: libodbc1:amd64\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
+    && echo "Package: odbcinst\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
+    && echo "Package: odbcinst1debian2:amd64\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
     && apt-get update \
     && apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -8,8 +8,15 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install prerequisites for the sqlsrv and pdo_sqlsrv PHP extensions.
+# Some packages are pinned with lower priority to prevent build issues due to package conflicts.
+# Link: https://github.com/microsoft/linux-package-repositories/issues/39
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && curl https://packages.microsoft.com/config/debian/11/prod.list > /etc/apt/sources.list.d/mssql-release.list \
+    && echo "Package: unixodbc\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
+    && echo "Package: unixodbc-dev\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
+    && echo "Package: libodbc1:amd64\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
+    && echo "Package: odbcinst\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
+    && echo "Package: odbcinst1debian2:amd64\nPin: origin \"packages.microsoft.com\"\nPin-Priority: 100\n" >> /etc/apt/preferences.d/microsoft \
     && apt-get update \
     && apt-get install -y msodbcsql18 mssql-tools18 unixodbc-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR fixes #7.

There is a package conflict regarding the `unixodbc` and `unixodbc-dev` packages as explained [in this issue](https://github.com/microsoft/linux-package-repositories/issues/39). The fix, [as kindly provided in this comment](https://github.com/microsoft/linux-package-repositories/issues/39#issuecomment-1446041805), is to pin the affected packages with a low priority to prevent the conflict.