### PR TITLE
Run integration tests against SQL Server 2019

### DIFF
--- a/.github/workflows/create-and-test-docker-image.yml
+++ b/.github/workflows/create-and-test-docker-image.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       sqlsrv:
-        image: mcr.microsoft.com/mssql/server:2017-latest
+        image: mcr.microsoft.com/mssql/server:2019-latest
         env:
           ACCEPT_EULA: Y
           SA_PASSWORD: ${{ secrets.TESTS_SQLSRV_DB_SECRET }}


### PR DESCRIPTION
Since SQL Server 2017 is already quite old, we now run the integration tests against a newer SQL Server version.