### PR TITLE
Add linux/arm64 as build platform for images

### DIFF
--- a/.github/workflows/create-and-test-docker-image.yml
+++ b/.github/workflows/create-and-test-docker-image.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           context: ${{ inputs.source-directory }}
           tags: ${{ inputs.image-tag }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           load: true
           
       - name: Test SQL Server connection
@@ -65,5 +65,5 @@ jobs:
         with:
           context: ${{ inputs.source-directory }}
           tags: ${{ inputs.image-tag }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true

--- a/.github/workflows/create-and-test-docker-image.yml
+++ b/.github/workflows/create-and-test-docker-image.yml
@@ -50,7 +50,6 @@ jobs:
           context: ${{ inputs.source-directory }}
           tags: ${{ inputs.image-tag }}
           platforms: linux/amd64,linux/arm64
-          load: true
           
       - name: Test SQL Server connection
         uses: addnab/docker-run-action@v3


### PR DESCRIPTION
This PR adds `linux/arm64` besides `linux/amd64` as build platform to images. Let's see if that works as easy as that.