### PR TITLE
Update mssql in builds to latest 2022 version

### DIFF
--- a/.github/workflows/create-and-test-docker-image.yml
+++ b/.github/workflows/create-and-test-docker-image.yml
@@ -18,14 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     services:
       sqlsrv:
-        image: mcr.microsoft.com/mssql/server:2019-latest
+        image: mcr.microsoft.com/mssql/server:2022-latest
         env:
           ACCEPT_EULA: Y
+          MSSQL_PID: Developer
           SA_PASSWORD: ${{ secrets.TESTS_SQLSRV_DB_SECRET }}
         ports:
           - 1433:1433
         options: >-
-          --health-cmd "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -Q 'SELECT 1' || exit 1"
+          --health-cmd "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -No -Q 'SELECT 1' || exit 1"
           --health-interval 10s
           --health-timeout 3s
           --health-retries 20


### PR DESCRIPTION
Until now, the built Docker images (or better said their drivers) have been tested against SQL Server 2019. Since we already have 2024, I guess its time to switch the test target to SQL Server 2022. From a compatibility standpoint, it shouldn't really matter though.