### PR TITLE
Fix debian distro to bookworm

### DIFF
--- a/8.1/cli/Dockerfile
+++ b/8.1/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli
+FROM php:8.1-cli-bookworm
 
 ENV ACCEPT_EULA=Y
 

--- a/8.1/fpm/Dockerfile
+++ b/8.1/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.1-fpm-bookworm
 
 ENV ACCEPT_EULA=Y
 

--- a/8.2/cli/Dockerfile
+++ b/8.2/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-cli
+FROM php:8.2-cli-bookworm
 
 ENV ACCEPT_EULA=Y
 

--- a/8.2/fpm/Dockerfile
+++ b/8.2/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.2-fpm-bookworm
 
 ENV ACCEPT_EULA=Y
 

--- a/8.3/cli/Dockerfile
+++ b/8.3/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.3-cli-bookworm
 
 ENV ACCEPT_EULA=Y
 

--- a/8.3/fpm/Dockerfile
+++ b/8.3/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-fpm
+FROM php:8.3-fpm-bookworm
 
 ENV ACCEPT_EULA=Y
 

--- a/8.4/cli/Dockerfile
+++ b/8.4/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-cli
+FROM php:8.4-cli-bookworm
 
 ENV ACCEPT_EULA=Y
 

--- a/8.4/fpm/Dockerfile
+++ b/8.4/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-fpm
+FROM php:8.4-fpm-bookworm
 
 ENV ACCEPT_EULA=Y
 


### PR DESCRIPTION
Some time ago, the official PHP images have been updated to Debian Trixie for the `<major>.<minor>-[cli|fpm]` tags. However, there is no msodbc driver available for this distribution just yet. The result is failed scheduled builds every sunday.

To fix this, we pin the images to Debian Bookworm. That also prevents breaking changes for users of the images.